### PR TITLE
Remove unused `json-lib` dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,13 +97,6 @@
         </dependency>
 
         <dependency>
-            <groupId>net.sf.json-lib</groupId>
-            <artifactId>json-lib</artifactId>
-            <version>2.4</version>
-            <classifier>jdk15</classifier>
-        </dependency>
-
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.3</version>


### PR DESCRIPTION
Looks like `json-lib` is not used for anything (I checked source imports and re-compiled, tested), but dependency remains (perhaps it was used earlier?). Since it would end up in `.war`, this PR is for removing dependency.
